### PR TITLE
Modern spm

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,21 +33,7 @@ let package = Package(
         )
     ],
     traits: [
-        // Default traits - enabled by default for backwards compatibility with CocoaPods
-        .default(enabledTraits: [
-            "Video",
-            "MapKit",
-            "Photos",
-            "AssetsLibrary"
-        ]),
-
-        // Define all traits with descriptions
-        .init(name: "Video", description: "Video node support with AVFoundation and CoreMedia"),
-        .init(name: "MapKit", description: "MapKit integration for map nodes"),
-        .init(name: "Photos", description: "Photos framework support"),
-        .init(name: "AssetsLibrary", description: "Legacy AssetsLibrary support (iOS only)"),
-
-        // Optional traits - must be explicitly enabled
+        // Optional traits
         .init(name: "IGListKit", description: "IGListKit integration for advanced collection view support")
     ],
     dependencies: [
@@ -65,19 +51,21 @@ let package = Package(
             path: "spm/Sources/AsyncDisplayKit",
             publicHeadersPath: "include",
             cSettings: [
-                // PINRemoteImage is always available
+                // Always available features
                 .define("AS_PIN_REMOTE_IMAGE", to: "1"),
 
                 // Disable old TextNode by default for SPM
                 .define("AS_ENABLE_TEXTNODE", to: "0"),
 
                 // Trait-based conditional defines
-                .define("AS_USE_VIDEO", to: "1", .when(traits: ["Video"])),
-                .define("AS_USE_MAPKIT", to: "1", .when(traits: ["MapKit"])),
-                .define("AS_USE_PHOTOS", to: "1", .when(traits: ["Photos"])),
-                .define("AS_USE_ASSETS_LIBRARY", to: "1", .when(traits: ["AssetsLibrary"])),
                 .define("AS_IG_LIST_KIT", to: "1", .when(traits: ["IGListKit"])),
                 .define("AS_IG_LIST_DIFF_KIT", to: "1", .when(traits: ["IGListKit"])),
+
+                // Disabled features
+                .define("AS_USE_VIDEO", to: "0"),           // Not accessible from Swift via SPM
+                .define("AS_USE_MAPKIT", to: "0"),          // Not accessible from Swift via SPM
+                .define("AS_USE_PHOTOS", to: "0"),          // Partially accessible from Swift via SPM
+                .define("AS_USE_ASSETS_LIBRARY", to: "0"),  // Deprecated iOS 9.0, use Photos framework
 
                 // Always disabled for SPM
                 .define("IG_LIST_COLLECTION_VIEW", to: "0"),
@@ -115,13 +103,10 @@ let package = Package(
                 .headerSearchPath("tvOS")
             ],
             linkerSettings: [
-                .linkedFramework("AVFoundation", .when(traits: ["Video"])),
-                .linkedFramework("CoreMedia", .when(traits: ["Video"])),
-                .linkedFramework("CoreLocation", .when(traits: ["MapKit"])),
-                .linkedFramework("MapKit", .when(traits: ["MapKit"])),
-                .linkedFramework("Photos", .when(traits: ["Photos"])),
-                .linkedFramework("AssetsLibrary", .when(platforms: [.iOS], traits: ["AssetsLibrary"])),
                 .linkedLibrary("c++")
+                // Note: Video/MapKit/Photos frameworks not linked by default
+                // These features are not accessible from Swift via SPM due to conditional compilation
+                // Use CocoaPods or Carthage if you need these features, or use Objective-C code
             ]
         ),
         .target(

--- a/README.md
+++ b/README.md
@@ -41,14 +41,23 @@ targets: [
 ```
 
 **Default Features (included automatically):**
-- Core AsyncDisplayKit (ASDisplayNode, ASImageNode, ASTextNode, etc.)
+- Core AsyncDisplayKit (ASDisplayNode, ASImageNode, ASTextNode2, ASButtonNode, etc.)
 - PINRemoteImage integration (ASPINRemoteImageDownloader)
-- Video support (AVFoundation, CoreMedia)
-- MapKit integration
-- Photos framework
-- AssetsLibrary (iOS only)
+- Collection views (ASCollectionNode, ASTableNode)
+- Layout specs (ASStackLayoutSpec, ASInsetLayoutSpec, etc.)
+- TextNode2 (modern text rendering, replaces legacy TextNode)
 
-**No trait configuration needed** - all these features work out of the box!
+**Optional Features (enable via traits):**
+- IGListKit integration (advanced collection views with modern Swift API)
+
+**⚠️ SPM Limitations:**
+Video (ASVideoNode), MapKit (ASMapNode), and Photos features are **not available** via Swift Package Manager due to technical limitations. These Objective-C classes are wrapped in conditional compilation directives (`#if AS_USE_VIDEO`) which prevents them from being exported in the Swift module interface.
+
+**If you need Video/MapKit/Photos features:**
+- Use **CocoaPods** or **Carthage** (full feature support)
+- Or use these features from **Objective-C code** (.m files)
+
+**Future directions:** We're exploring solutions like Swift wrapper modules (TextureVideoExtensions, TextureMapKitExtensions) to provide Swift API for these features via SPM.
 
 #### Advanced Usage: IGListKit Integration
 
@@ -95,16 +104,18 @@ If you're migrating from CocoaPods, here's how the subspecs map to SPM features:
 |---------|-----------|-----|-------|
 | **Core** | `pod 'Texture'` (default) | `.product(name: "AsyncDisplayKit", ...)` | ✅ Always included |
 | **PINRemoteImage** | Included by default | Always included | ✅ Same behavior |
-| **Video** | Included by default | Default trait (enabled) | ✅ Same behavior |
-| **MapKit** | Included by default | Default trait (enabled) | ✅ Same behavior |
-| **Photos** | Included by default | Default trait (enabled) | ✅ Same behavior |
-| **AssetsLibrary** | Included by default | Default trait (enabled) | ✅ Same behavior |
-| **IGListKit** | `pod 'Texture/IGListKit'` | Trait + product (see above) | ⚠️ Uses IGListKit 5.0+ |
+| **Video** | Included by default | **Not available** | ❌ SPM limitation (see above) |
+| **MapKit** | Included by default | **Not available** | ❌ SPM limitation (see above) |
+| **Photos** | Included by default | **Not available** | ❌ SPM limitation (see above) |
+| **AssetsLibrary** | Included by default | **Removed** | ❌ Deprecated iOS 9.0, use Photos |
+| **IGListKit** | `pod 'Texture/IGListKit'` | Optional trait + product | ⚠️ Uses IGListKit 5.0+ |
 | **TextNode2** | `pod 'Texture/TextNode2'` | Enabled by default | ✅ Modern TextNode used |
 | **Yoga** | `pod 'Texture/Yoga'` | Not supported | Add as separate dependency |
 
 **Key differences:**
 - **TextNode2 is default**: SPM uses the modern TextNode implementation automatically (no legacy TextNode)
+- ❌ **Video/MapKit/Photos not available**: Due to Swift Package Manager limitations with conditionally compiled Objective-C classes
+- ❌ **AssetsLibrary removed**: Deprecated in iOS 9.0, use Photos framework instead
 - ⚠️ **IGListKit version**: SPM uses IGListKit 5.0+ instead of 4.x (breaking changes)
 - ℹ️ **Yoga**: Not integrated in SPM - add Yoga as a separate dependency if needed
 

--- a/examples/SPMBasic/README.md
+++ b/examples/SPMBasic/README.md
@@ -1,37 +1,25 @@
 # SPM Basic Example
 
-This example demonstrates basic Texture usage via Swift Package Manager with default traits.
+This example demonstrates basic Texture usage via Swift Package Manager.
 
-## Features
+## What This Tests
 
-This example uses Texture with default traits enabled:
-- Video support (AVFoundation, CoreMedia)
-- MapKit integration
-- Photos framework
-- AssetsLibrary (iOS only)
+This example verifies that core Texture functionality works via SPM:
+- Basic nodes (ASDisplayNode, ASImageNode, ASTextNode, ASButtonNode)
+- Collection views (ASCollectionNode, ASTableNode)
+- Layout specs (ASStackLayoutSpec, ASInsetLayoutSpec, ASCenterLayoutSpec, ASBackgroundLayoutSpec)
+- PINRemoteImage integration (ASPINRemoteImageDownloader, ASNetworkImageNode)
 
-## Building
+## SPM Limitations
 
-From this directory:
+**Note:** Video (ASVideoNode), MapKit (ASMapNode), and Photos features are **not available** via SPM due to Swift Package Manager limitations with conditionally compiled Objective-C classes. These features remain available via CocoaPods and Carthage.
 
-```bash
-swift build
-```
+## Running Tests
 
-## Running
+From the repository root:
 
 ```bash
-swift run
+./build.sh spm-texture-basic
 ```
 
-Expected output:
-```
-✓ Texture (AsyncDisplayKit) imported successfully via SPM!
-Creating basic nodes...
-✓ ASDisplayNode created
-✓ ASImageNode created
-✓ ASTextNode created
-
-✅ All basic Texture features are working with SPM!
-Default traits enabled: Video, MapKit, Photos, AssetsLibrary
-```
+This will build and run all tests to verify core Texture functionality works correctly with SPM.

--- a/examples/SPMBasic/Tests/DefaultTraitsTests.swift
+++ b/examples/SPMBasic/Tests/DefaultTraitsTests.swift
@@ -4,9 +4,10 @@ import AsyncDisplayKit
 
 /// Tests that verify basic Texture functionality works via SPM
 ///
-/// Note: Default traits (Video, MapKit, Photos, AssetsLibrary) are enabled,
-/// but trait-specific Objective-C classes may not be accessible from Swift
-/// without additional bridging. These tests focus on core Texture functionality.
+/// Note: Video/MapKit/Photos features are not available via SPM due to Swift Package Manager
+/// limitations with conditionally compiled Objective-C classes (#if guards).
+/// These features remain available via CocoaPods and Carthage.
+/// These tests focus on core Texture functionality that works with SPM.
 
 @Suite("Basic Texture Nodes")
 struct BasicTextureNodesTests {


### PR DESCRIPTION
 ### Summary

  This PR adds Swift Package Manager (SPM) support to Texture using Package Traits (Swift 6.1+) with optional IGListKit integration.

  Quick Start

  To test this PR, add to your Package.swift:

```swift
  dependencies: [
      .package(url: "https://github.com/TextureGroup/Texture.git", branch: "modern-spm")
  ]

  targets: [
      .target(
          name: "YourTarget",
          dependencies: [
              .product(name: "AsyncDisplayKit", package: "Texture")
          ]
      )
  ]
```
  After merge, use version-based dependency:

```swift
  dependencies: [
      .package(url: "https://github.com/TextureGroup/Texture.git", from: "3.3.0")
  ]
```
  What's Included

  Default features:
  - Core AsyncDisplayKit (ASDisplayNode, ASImageNode, ASTextNode2, ASButtonNode, etc.)
  - PINRemoteImage integration (ASPINRemoteImageDownloader)
  - Collection views (ASCollectionNode, ASTableNode)
  - Layout specs (ASStackLayoutSpec, ASInsetLayoutSpec, etc.)
  - TextNode2 (modern text rendering)

  Optional features:
  - IGListKit integration (enable via trait - see below)

 ### SPM Limitations

Video (ASVideoNode), MapKit (ASMapNode), and Photos features **are NOT AVAILABLE** via SPM due to Swift Package Manager limitations with conditionally compiled Objective-C classes. These features remain available via CocoaPods and Carthage. If you need Video/MapKit/Photos features:
  - Use CocoaPods or Carthage
  - Or use these features from Objective-C code (.m files)


###  IGListKit Integration (Optional)
 
For library packages (testing this PR):

```swift

  dependencies: [
      .package(
          url: "https://github.com/TextureGroup/Texture.git",
          branch: "modern-spm",
          traits: [.init(name: "IGListKit")]
      )
  ]

  targets: [
      .target(
          name: "YourTarget",
          dependencies: [
              .product(name: "AsyncDisplayKit", package: "Texture"),
              .product(name: "TextureIGListKitExtensions", package: "Texture")
          ]
      )
  ]
```

 - For iOS/tvOS apps:

 Due to Xcode 26.0.1 limitations, create a local package wrapper to enable traits. See Sources/TextureIGListKitExtensions/README.md for a complete guide.

  Important notes:
  - SPM uses IGListKit 5.0+ (breaking changes from 4.x used in CocoaPods/Carthage)
  - Pure Swift API: adapter.setCollectionNode(node) (replaces Objective-C setASDKCollectionNode:)
  - Not a drop-in replacement - migration and testing required

  Examples

  - examples/SPMBasic - Basic AsyncDisplayKit usage
  - examples/SPMWithIGListKit - Library package with IGListKit trait
  - examples/ASIGListKitSPM - iOS app integration with local package wrapper

  Technical Details

  Architecture:
  - AsyncDisplayKit target provides core framework
  - TextureIGListKitExtensions target provides pure Swift IGListKit bridge (SPM-only)
  - Symlink-based layout generated via scripts/generate_spm_sources_layout.swift

 ### Why symlinks?

Previous SPM attempts required changing #import <AsyncDisplayKit/Foo.h> to #import "Foo.h" across hundreds of files. Symlinks preserve original imports while supporting all package managers simultaneously. 

  Platform requirements:
  - iOS 14.0+ / tvOS 14.0+ / Mac Catalyst 13.0+
  - Swift 6.1+ (Package Traits support)
  - Xcode 26.0+

  Migration from CocoaPods

  | Feature        | CocoaPods               | SPM                                    | Notes                  |
  |----------------|-------------------------|----------------------------------------|------------------------|
  | Core           | pod 'Texture'           | .product(name: "AsyncDisplayKit", ...) | ✅ Same                 |
  | PINRemoteImage | Default                 | Default                                | ✅ Same                 |
  | Video          | Default                 | Not available                          | ❌ SPM limitation       |
  | MapKit         | Default                 | Not available                          | ❌ SPM limitation       |
  | Photos         | Default                 | Not available                          | ❌ SPM limitation       |
  | AssetsLibrary  | Default                 | Removed                                | ❌ Deprecated iOS 9.0   |
  | IGListKit      | pod 'Texture/IGListKit' | Optional trait + product               | ⚠️ Uses IGListKit 5.0+ |
  | TextNode2      | pod 'Texture/TextNode2' | Default                                | ✅ Always enabled       |

  ### CI/CD Integration

  New build modes added:
  - spm - Build with default traits
  - spm-texture-basic - Test basic functionality (validates committed layout)
  - spm-texture-iglistkit - Test IGListKit trait (validates generation script)
  - spm-app-iglistkit - Test iOS app integration

  All existing builds (CocoaPods, Carthage, Framework) unaffected.

  ### Breaking Changes

  None for existing CocoaPods/Carthage users. SPM is a new installation method.