### PR TITLE
Fix modulemap: use umbrella directory

### DIFF
--- a/Source/AsyncDisplayKit.modulemap
+++ b/Source/AsyncDisplayKit.modulemap
@@ -1,19 +1,19 @@
 framework module AsyncDisplayKit {
-  umbrella header "AsyncDisplayKit.h"
-  
+  umbrella "Headers"
+
   export *
   module * {
     export *
   }
-  
+
   explicit module ASControlNode_Subclasses {
     header "ASControlNode+Subclasses.h"
     export *
   }
-  
+
   explicit module ASDisplayNode_Subclasses {
     header "ASDisplayNode+Subclasses.h"
     export *
   }
-  
+
 }


### PR DESCRIPTION
## Problem

Binary XCFramework shows Xcode warnings about public headers not in umbrella header. Headers like `_*.h` are public but not imported in `AsyncDisplayKit.h`.

## Solution

Changed modulemap from `umbrella header "AsyncDisplayKit.h"` to `umbrella "Headers"`.

This automatically includes all headers from Headers directory.

## Impact

- Binary XCFramework (SPM): Eliminates warnings
- Carthage: No change (works correctly)
- CocoaPods: No impact (generates own modulemap)
- SPM Source: No impact (generates own modulemap)

## Testing

- Built locally with `./scripts/build_xcframework.sh`
- Tested in SPM project with `swift build` and `xcodebuild`
- No warnings