### PR TITLE
Hotfix: explicit @objc selectors for Interop methods

### DIFF
--- a/Sources/TextureIGListKitExtensions/IGListAdapter+Texture.swift
+++ b/Sources/TextureIGListKitExtensions/IGListAdapter+Texture.swift
@@ -443,17 +443,26 @@ public import IGListDiffKit
     /// Required by `ASCollectionDataSourceInterop` (runtime-declared above in
     /// `conforms(to:)`). AsyncDisplayKit relies on these forwarders to bridge
     /// `IGListAdapter`'s UIKit data-source path to ASCollectionNode's interop layer.
-    /// Without them, the runtime conformance is a lie and `ASCollectionView` may
-    /// drop willDisplay callbacks or attempt to dequeue cells through the wrong path.
-    @objc func collectionView(_ collectionView: UICollectionView,
-                              cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    ///
+    /// The explicit `@objc(...)` selectors are critical: AsyncDisplayKit calls
+    /// these methods with the historical UIKit selector names (e.g.
+    /// `collectionView:cellForItemAtIndexPath:`, with the `IndexPath` suffix).
+    /// Swift's automatic `@objc` name generation derives the selector from the
+    /// Swift argument labels, producing `collectionView:cellForItemAt:`, which
+    /// the Obj-C runtime does not recognize. Without the explicit names, ASCollectionView
+    /// hits `_CF_forwarding_prep_0` → "unrecognized selector sent to instance"
+    /// on the very first cell dequeue.
+    @objc(collectionView:cellForItemAtIndexPath:)
+    func collectionView(_ collectionView: UICollectionView,
+                        cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let dataSource = dataSource else { return UICollectionViewCell() }
         return dataSource.collectionView(collectionView, cellForItemAt: indexPath)
     }
 
-    @objc func collectionView(_ collectionView: UICollectionView,
-                              viewForSupplementaryElementOfKind kind: String,
-                              at indexPath: IndexPath) -> UICollectionReusableView {
+    @objc(collectionView:viewForSupplementaryElementOfKind:atIndexPath:)
+    func collectionView(_ collectionView: UICollectionView,
+                        viewForSupplementaryElementOfKind kind: String,
+                        at indexPath: IndexPath) -> UICollectionReusableView {
         guard let dataSource = dataSource,
               let view = dataSource.collectionView?(collectionView,
                                                    viewForSupplementaryElementOfKind: kind,
@@ -465,15 +474,17 @@ public import IGListDiffKit
 
     // MARK: - ASCollectionDelegateInterop
 
-    @objc func collectionView(_ collectionView: UICollectionView,
-                              willDisplay cell: UICollectionViewCell,
-                              forItemAt indexPath: IndexPath) {
+    @objc(collectionView:willDisplayCell:forItemAtIndexPath:)
+    func collectionView(_ collectionView: UICollectionView,
+                        willDisplay cell: UICollectionViewCell,
+                        forItemAt indexPath: IndexPath) {
         delegate?.collectionView?(collectionView, willDisplay: cell, forItemAt: indexPath)
     }
 
-    @objc func collectionView(_ collectionView: UICollectionView,
-                              didEndDisplaying cell: UICollectionViewCell,
-                              forItemAt indexPath: IndexPath) {
+    @objc(collectionView:didEndDisplayingCell:forItemAtIndexPath:)
+    func collectionView(_ collectionView: UICollectionView,
+                        didEndDisplaying cell: UICollectionViewCell,
+                        forItemAt indexPath: IndexPath) {
         delegate?.collectionView?(collectionView, didEndDisplaying: cell, forItemAt: indexPath)
     }
 }


### PR DESCRIPTION
## Summary

Hotfix for the regression introduced in #8. The four \`ASCollectionDataSourceInterop\` / \`ASCollectionDelegateInterop\` forwarders relied on Swift's automatic \`@objc\` selector generation. Those protocols are declared at runtime via the \`conforms(to:)\` override (not as compile-time conformance), so Swift's protocol method imap doesn't reach them — the generated Obj-C selectors are derived purely from Swift argument labels and miss the historical UIKit \`atIndexPath:\` / \`forItemAtIndexPath:\` suffixes that AsyncDisplayKit calls with.

Result: on the very first cell dequeue the Obj-C runtime fell through to \`_CF_forwarding_prep_0\` and crashed with \`unrecognized selector sent to instance\`.

Annotate each Interop forwarder with the historical selector:

| Swift name | Explicit Obj-C selector |
|---|---|
| \`collectionView(_:cellForItemAt:)\` | \`collectionView:cellForItemAtIndexPath:\` |
| \`collectionView(_:viewForSupplementaryElementOfKind:at:)\` | \`collectionView:viewForSupplementaryElementOfKind:atIndexPath:\` |
| \`collectionView(_:willDisplay:forItemAt:)\` | \`collectionView:willDisplayCell:forItemAtIndexPath:\` |
| \`collectionView(_:didEndDisplaying:forItemAt:)\` | \`collectionView:didEndDisplayingCell:forItemAtIndexPath:\` |

The other Fix #2 additions (supplementary node providers, batch fetching, header/footer sizing) are part of compile-time protocol conformance on \`ASCollectionDataSource\` / \`ASCollectionDelegate\` / \`ASCollectionDelegateFlowLayout\`, so Swift's protocol method imap maps them to the right selectors automatically — no change needed there.

## Verification

\`build.sh spm-texture-iglistkit\` (xcodebuild + \`SPMWithIGListKitTests\`, iOS Simulator 26.4.1) — clean build, all tests pass.