### PR TITLE
feat(TextureIGListKitExtensions): add performUpdatesWithFallback with pre-flight section-count guard

### DIFF
--- a/Sources/TextureIGListKitExtensions/IGListAdapter+Texture.swift
+++ b/Sources/TextureIGListKitExtensions/IGListAdapter+Texture.swift
@@ -8,9 +8,16 @@
 
 import Foundation
 import ObjectiveC
+import os.log
 public import AsyncDisplayKit
 public import IGListKit
 public import IGListDiffKit
+
+/// Subsystem-scoped log used by the section-count guard in
+/// `ListAdapter.performUpdatesWithFallback`. Reads in Console.app under
+/// `subsystem: TextureIGListKitExtensions`, `category: iglistkit-guard`.
+private let iglistkitGuardLog = OSLog(subsystem: "TextureIGListKitExtensions",
+                                      category: "iglistkit-guard")
 
 /// Pure Swift data source bridge between IGListKit and AsyncDisplayKit
 ///
@@ -789,6 +796,83 @@ extension ListAdapter {
         } else {
             collectionNode.onDidLoad { [weak self] node in
                 self?.collectionView = node.view as? UICollectionView
+            }
+        }
+    }
+
+    /// Performs `performUpdates(animated:completion:)` after a pre-flight check that the
+    /// collection view's section count matches the adapter's last applied object count.
+    /// If the counts diverge, falls back to `reloadData(completion:)` instead of letting
+    /// IGListKit raise `NSInternalInconsistencyException` from
+    /// `IGListBatchUpdateTransaction._didDiff:onBackground:` with the message
+    ///
+    ///     The UICollectionView's section count (N) didn't match the
+    ///     IGListAdapter's count (M), so we can't performBatchUpdates.
+    ///     Falling back to reloadData.
+    ///
+    /// (IGListKit's own message text says "falling back to reloadData", but `IGAssert`
+    /// raises an NSException in release builds — the documented fallback never executes.)
+    ///
+    /// ## When this guard catches the mismatch
+    ///
+    /// The pre-flight catches **already-divergent** states: the collection view was reset
+    /// externally (e.g. `reloadData` called from another code path, the data source was
+    /// reassigned, the view was re-laid out and lost its section count) while the adapter
+    /// still holds the previous applied snapshot.
+    ///
+    /// ## When this guard does NOT catch the mismatch
+    ///
+    /// It does **not** prevent the same exception when the divergence is produced by a
+    /// concurrent in-flight diff. IGListKit captures a `sectionMap` snapshot inside its
+    /// background diff queue; a second `performUpdates` that mutates the data source
+    /// between snapshot and apply will still raise from `_didDiff:onBackground:` —
+    /// the assertion fires inside IGListKit, after this guard has already returned.
+    /// To prevent that race, the caller must serialize concurrent loads on the same
+    /// adapter (cancel the in-flight task before kicking off a new one).
+    ///
+    /// Use this in tandem with a serialization strategy, not as a replacement for one.
+    ///
+    /// - Parameters:
+    ///   - animated: Forwarded to `performUpdates` when the pre-flight check passes.
+    ///     Ignored on the `reloadData` fallback path — `reloadData` is never animated.
+    ///   - completion: Invoked when either `performUpdates` or `reloadData` finishes.
+    ///     The `Bool` argument matches `performUpdates` semantics on the normal path.
+    ///     On the `reloadData` fallback path the value is always `true`, since
+    ///     `reloadData` has no concept of a partial result.
+    @MainActor
+    public func performUpdatesWithFallback(animated: Bool,
+                                   completion: ((Bool) -> Void)? = nil) {
+        guard let view = collectionView else {
+            performUpdates(animated: animated, completion: completion)
+            return
+        }
+
+        let viewSections = view.numberOfSections
+        let adapterSections = objects().count
+
+        if viewSections != adapterSections {
+            os_log(.error, log: iglistkitGuardLog,
+                   "performUpdatesWithFallback: section-count divergence (view=%{public}d, adapter=%{public}d) — falling back to reloadData",
+                   viewSections, adapterSections)
+            reloadData { _ in
+                completion?(true)
+            }
+            return
+        }
+
+        performUpdates(animated: animated, completion: completion)
+    }
+
+    /// `async` overload of `performUpdatesWithFallback(animated:completion:)`.
+    /// Suspends until the underlying `performUpdates` or `reloadData` fallback finishes,
+    /// matching the `await adapter.performUpdates(animated:)` call shape that the
+    /// completion-handler bridge produces for `performUpdates`.
+    @MainActor
+    @discardableResult
+    public func performUpdatesWithFallback(animated: Bool) async -> Bool {
+        await withCheckedContinuation { continuation in
+            performUpdatesWithFallback(animated: animated) { finished in
+                continuation.resume(returning: finished)
             }
         }
     }

--- a/examples/SPMWithIGListKit/Tests/IGListAdapterBridgeTests.swift
+++ b/examples/SPMWithIGListKit/Tests/IGListAdapterBridgeTests.swift
@@ -344,6 +344,90 @@ struct IGListAdapterBridgeTests {
         #expect(headerAttributes?.size.height ?? 0 > 0,
                 "Header layout reported zero height; sizeRangeForHeaderInSection: forwarder is not returning the section controller's size")
     }
+
+    /// Pre-flight guard in `performUpdatesWithFallback` must let normal diffs flow through:
+    /// when `collectionView.numberOfSections` already matches
+    /// `adapter.objects().count`, the call must dispatch to `performUpdates(animated:)`
+    /// and apply the diff exactly as a direct call to `performUpdates(animated:)` would.
+    /// This is the common case — the guard must not regress it.
+    @Test("performUpdatesWithFallback applies diffs when section counts match")
+    func performUpdatesWithFallback_appliesDiffs_whenSectionCountsMatch() async {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 568))
+        let viewController = UIViewController()
+        window.rootViewController = viewController
+        window.makeKeyAndVisible()
+
+        let collectionNode = ASCollectionNode(collectionViewLayout: UICollectionViewFlowLayout())
+        collectionNode.frame = window.bounds
+        viewController.view.addSubnode(collectionNode)
+        _ = collectionNode.view
+
+        let adapter = ListAdapter(updater: ListAdapterUpdater(),
+                                  viewController: viewController,
+                                  workingRangeSize: 0)
+        let dataSource = TestListAdapterDataSource(items: [])
+        adapter.dataSource = dataSource
+        adapter.setCollectionNode(collectionNode)
+
+        // 0 → 2 sections through the fallback-aware entry point.
+        dataSource.items = [TestItem(id: 1), TestItem(id: 2)]
+        await adapter.performUpdatesWithFallback(animated: false)
+        collectionNode.view.layoutIfNeeded()
+        #expect(collectionNode.view.numberOfSections == 2)
+
+        // 2 → 4 sections through the fallback-aware entry point on a subsequent diff.
+        dataSource.items = [TestItem(id: 1), TestItem(id: 2), TestItem(id: 3), TestItem(id: 4)]
+        await adapter.performUpdatesWithFallback(animated: false)
+        collectionNode.view.layoutIfNeeded()
+        #expect(collectionNode.view.numberOfSections == 4)
+    }
+
+    // NOTE: There is no companion regression test that exercises the
+    // `reloadData(completion:)` fallback branch in `performUpdatesWithFallback`. The branch is
+    // reached when `collectionView.numberOfSections != adapter.objects().count`, a state
+    // that the IGListKit + AsyncDisplayKit API contract intentionally prevents callers
+    // from constructing directly:
+    //
+    //   - Swapping `collectionNode.dataSource` to a non-bridge stand-in crashes during
+    //     layout: AsyncDisplayKit's interop layer dispatches UIKit-historical selectors
+    //     (`collectionView:cellForItemAtIndexPath:` etc.) at the data source, and only
+    //     `IGListAdapterDataSourceBridge` runtime-conforms to them. A `UIKit`/`ASDK`
+    //     data source that omits the runtime conformance hits "unrecognized selector"
+    //     on the first cell dequeue.
+    //   - Subclassing `ListAdapter` to stub `objects()` fails at compile time because
+    //     `IGListAdapter` is not declared `open` outside its defining module.
+    //   - Method swizzling `UICollectionView.numberOfSections` leaks across other tests
+    //     in the same process and breaks the unrelated bridge-regression coverage above.
+    //
+    // The fallback branch is a single `if` with a small body and is verified by
+    // inspection of `performUpdatesWithFallback(animated:completion:)` in
+    // `IGListAdapter+Texture.swift`. The two tests above (happy path; nil collection
+    // view) catch regressions in the surrounding contract (signature, completion
+    // semantics, no-op forwarding) that would otherwise mask a broken fallback.
+
+    /// `performUpdatesWithFallback` must remain callable before a collection view is attached.
+    /// IGListAdapter accepts `performUpdates` with no collection view (it becomes a
+    /// no-op that still invokes completion), and the guard must not change that
+    /// contract — it should fall through to `performUpdates` directly without
+    /// dereferencing the nil view.
+    ///
+    /// The completion's `Bool` argument matches whatever the underlying
+    /// `performUpdates` returns in this state (typically `false`, since no batch
+    /// update actually ran). The contract this test enforces is "does not crash and
+    /// invokes the completion handler exactly once" — the specific value is incidental.
+    @Test("performUpdatesWithFallback is a no-op when no collection view is attached")
+    func performUpdatesWithFallback_isNoOp_whenNoCollectionViewAttached() async {
+        let adapter = ListAdapter(updater: ListAdapterUpdater(),
+                                  viewController: nil,
+                                  workingRangeSize: 0)
+        let dataSource = TestListAdapterDataSource(items: [TestItem(id: 1)])
+        adapter.dataSource = dataSource
+
+        // No setCollectionNode call — adapter.collectionView is nil. The guard's nil
+        // branch forwards to performUpdates. Test must not crash and must receive the
+        // callback.
+        _ = await adapter.performUpdatesWithFallback(animated: false)
+    }
 }
 
 // MARK: - Fixtures


### PR DESCRIPTION
## Summary

Adds `ListAdapter.performUpdatesWithFallback(animated:completion:)` (plus an async overload) that performs a pre-flight check `UICollectionView.numberOfSections == adapter.objects().count` and falls back to `reloadData(completion:)` on divergence, instead of letting IGListKit raise `NSInternalInconsistencyException` from `IGListBatchUpdateTransaction._didDiff:onBackground:` with

> The UICollectionView's section count (N) didn't match the IGListAdapter's count (M), so we can't performBatchUpdates. Falling back to reloadData.

(IGListKit's message text says "falling back to reloadData", but `IGAssert` raises an NSException in release builds — the documented fallback never executes.)

## Scope

Catches **already-divergent** states, where the collection view was reset externally (`reloadData` from another path, data source reassignment, view re-layout that lost its section count) while the adapter still holds the previous applied snapshot.

## Out of scope

Does **not** prevent the same exception when triggered by a concurrent in-flight diff: IGListKit captures the `sectionMap` inside its background diff queue, and a second `performUpdates` that mutates the data source between snapshot and apply still raises from `_didDiff:onBackground:`. Callers must serialize concurrent loads on the same adapter — this guard is a defence-in-depth layer, not a replacement for caller-side serialization.

Also out of scope: `ASCollectionInvalidUpdateException` raised from `ASDataController.mm:598` when a changeSet validates against a data source already mutated by a subsequent load. That race requires caller-side serialization of the load → performUpdates cycle.

## Tests

`IGListAdapterBridgeTests` adds:

- `performUpdatesWithFallback_appliesDiffs_whenSectionCountsMatch` — happy path, ensures the guard does not regress normal consecutive diffs.
- `performUpdatesWithFallback_isNoOp_whenNoCollectionViewAttached` — verifies the nil-collectionView fall-through to `performUpdates`.

The fallback branch is not exercised by a dedicated test because the IGListKit + AsyncDisplayKit API contract intentionally prevents callers from constructing the divergent precondition (dataSource swaps crash on interop selectors; `IGListAdapter` is not open for subclassing outside its defining module; method-swizzling `UICollectionView.numberOfSections` would leak across the surrounding regression tests). The branch is one `if` statement and is verified by inspection; an inline comment in the test file documents this rationale.

Local run on iPhone 17 / iOS 26.4.1 simulator: **9/9 tests passed** (7 existing regression + 2 new).

## Observability

Divergence events are logged via `os_log` at `.error` level under `subsystem: TextureIGListKitExtensions`, `category: iglistkit-guard`. Consumers can filter for these in Console.app or pipe them into their structured-logging stack to measure how often the fallback fires in production.

## Test plan

- [ ] Verify CI passes on the SPMWithIGListKit test scheme (iOS Simulator).
- [ ] Confirm public API addition is acceptable (new method on `ListAdapter`) — no breaking changes to existing API.
- [ ] Tag a patch release (e.g. `3.3.5`) once merged so SPM consumers can pin the new revision.